### PR TITLE
Allow empty certFile and keyFile for ListenTLS() (Fixes #99)

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -172,10 +172,12 @@ func (srv *Server) ListenTLS(certFile, keyFile string) (net.Listener, error) {
 	}
 
 	var err error
-	config.Certificates = make([]tls.Certificate, 1)
-	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, err
+	if certFile != "" && keyFile != "" {
+		config.Certificates = make([]tls.Certificate, 1)
+		config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Enable http2


### PR DESCRIPTION
In order to use multiple TLS certificates that can be added/removed dynamically at runtime, without restarting the server, `config.Certificates` must be empty and `tls.Config.GetCertificate` must be implemented as documented [here](https://golang.org/pkg/crypto/tls/#Config).

This commit allows the user to leave the `Certificates` slice empty, so `tls.Config.GetCertificate` can be used.